### PR TITLE
remove filterUndefined

### DIFF
--- a/src/utils/filterUndefined.ts
+++ b/src/utils/filterUndefined.ts
@@ -1,3 +1,0 @@
-export function filterUndefined<T>(ts: (T | undefined)[]): T[] {
-	return ts.filter((t: T | undefined): t is T => !!t);
-}


### PR DESCRIPTION
This PR removes filterUndefined. This is more a question of taste. I wanted to remove filterUndefined as it is actually a removeFalsy-function as it is also removing values like null or false. 

I guess, that the jobProcessingQueue only returns Jobs with existing _id. I suppose because the typing of Job attrs _id is optional typescript makes the return value of the map() be ObjectId or undefined. So we were enforced to put it through the filterUndefined method to have only ObjectIds. By typing the _id attribute to be explicitly being an ObjectId we can ensure that typescript thinks that we  have an array of ObjectIds. To be sure we actually did need the filter, we filter also with a simple n => n to be on the safe side. 