### PR TITLE
Set fields to delete explicitly to null instead of undefined

### DIFF
--- a/src/JobDbRepository.ts
+++ b/src/JobDbRepository.ts
@@ -248,14 +248,14 @@ export class JobDbRepository {
 	async saveJobState(job: Job<any>): Promise<void> {
 		const id = job.attrs._id;
 		const $set = {
-			lockedAt: (job.attrs.lockedAt && new Date(job.attrs.lockedAt)) || undefined,
-			nextRunAt: (job.attrs.nextRunAt && new Date(job.attrs.nextRunAt)) || undefined,
-			lastRunAt: (job.attrs.lastRunAt && new Date(job.attrs.lastRunAt)) || undefined,
+			lockedAt: (job.attrs.lockedAt && new Date(job.attrs.lockedAt)) || null,
+			nextRunAt: (job.attrs.nextRunAt && new Date(job.attrs.nextRunAt)) || null,
+			lastRunAt: (job.attrs.lastRunAt && new Date(job.attrs.lastRunAt)) || null,
 			progress: job.attrs.progress,
 			failReason: job.attrs.failReason,
 			failCount: job.attrs.failCount,
 			failedAt: job.attrs.failedAt && new Date(job.attrs.failedAt),
-			lastFinishedAt: (job.attrs.lastFinishedAt && new Date(job.attrs.lastFinishedAt)) || undefined
+			lastFinishedAt: (job.attrs.lastFinishedAt && new Date(job.attrs.lastFinishedAt)) || null
 		};
 
 		log('[job %s] save job state: \n%O', id, $set);


### PR DESCRIPTION
I use Meteor at work, and it [configures the MongoDB drivers to ignore `undefined`](https://github.com/meteor/meteor/blob/aef10cb4138013fe1eed60b79a08ff669bb248ae/packages/mongo/mongo_driver.js#L162-L164) values when updating a field instead of setting the field to `null` (unlike the MongoDB driver, which [does not ignore `undefined` by default](https://www.mongodb.com/docs/drivers/node/current/fundamentals/bson/undefined-values/)).

This behavior caused a specific issue where the same job document was repeatedly fetched, resulting in a job running in a loop until the lock is released due to the end of the lock time. The document would match because of the second condition in this `$or` query, as the `lockedAt` field wasn't set to `null` as expected:

https://github.com/hokify/agenda/blob/16a7e8b226ac8c95130a030ecba193c87871f6cf/src/JobDbRepository.ts#L133-L146

However, explicitly setting the fields to `null` instead of `undefined` is a better practice because, in the end, they turn into `null` in the database. Also, not ignoring `undefined` and turning it into `null` feels weeeiiiird.

If someone else is facing the same issue, a possible fix is adding this option to your `settings.json` file:

```json
"packages": {
    "mongo": {
        "options": {
            "ignoreUndefined": false
        }
    }
}
```

This configuration ensures that setting a field to `undefined` actually sets it to `null`. But please note that if you have code relying on the previous behavior, this fix could potentially break something else.

