### PR TITLE
Support MongoDB driver 6.0

### DIFF
--- a/src/JobDbRepository.ts
+++ b/src/JobDbRepository.ts
@@ -18,6 +18,11 @@ import { hasMongoProtocol } from './utils/hasMongoProtocol';
 
 const log = debug('agenda:db');
 
+const findOneAndUpdateCommonOptions = {
+    includeResultMetadata: true, // mongodb driver 6.0 default is false, so we use true for backwards compatibility
+    returnDocument: 'after'
+};
+
 /**
  * @class
  */
@@ -107,8 +112,8 @@ export class JobDbRepository {
 		// Update / options for the MongoDB query
 		const update: UpdateFilter<IJobParameters> = { $set: { lockedAt: new Date() } };
 		const options: FindOneAndUpdateOptions = {
-			returnDocument: 'after',
-			sort: this.connectOptions.sort
+			sort: this.connectOptions.sort,
+      ...findOneAndUpdateCommonOptions
 		};
 
 		// Lock the job in MongoDB!
@@ -154,8 +159,8 @@ export class JobDbRepository {
 		 * Query used to affect what gets returned
 		 */
 		const JOB_RETURN_QUERY: FindOneAndUpdateOptions = {
-			returnDocument: 'after',
-			sort: this.connectOptions.sort
+			sort: this.connectOptions.sort,
+      ...findOneAndUpdateCommonOptions
 		};
 
 		// Find ONE and ONLY ONE job and set the 'lockedAt' time so that job begins to be processed
@@ -313,7 +318,7 @@ export class JobDbRepository {
 				const result = await this.collection.findOneAndUpdate(
 					{ _id: id, name: props.name },
 					update,
-					{ returnDocument: 'after' }
+					{ ...findOneAndUpdateCommonOptions }
 				);
 				return this.processDbResult(job, result.value as IJobParameters<DATA>);
 			}
@@ -352,7 +357,7 @@ export class JobDbRepository {
 					update,
 					{
 						upsert: true,
-						returnDocument: 'after'
+						...findOneAndUpdateCommonOptions
 					}
 				);
 				log(

--- a/src/JobDbRepository.ts
+++ b/src/JobDbRepository.ts
@@ -25,7 +25,7 @@ interface FindOneAndUpdateOptions extends FindOneAndUpdateOptions_orig {
 const findOneAndUpdateCommonOptions = {
     includeResultMetadata: true, // mongodb driver 6.0 default is false, so we use true for backwards compatibility
     returnDocument: 'after'
-};
+} as FindOneAndUpdateOptions;
 
 /**
  * @class

--- a/src/JobDbRepository.ts
+++ b/src/JobDbRepository.ts
@@ -3,7 +3,7 @@ import {
 	Collection,
 	Db,
 	Filter,
-	FindOneAndUpdateOptions,
+	FindOneAndUpdateOptions as FindOneAndUpdateOptions_orig,
 	MongoClient,
 	MongoClientOptions,
 	ObjectId,
@@ -17,6 +17,10 @@ import type { IJobParameters } from './types/JobParameters';
 import { hasMongoProtocol } from './utils/hasMongoProtocol';
 
 const log = debug('agenda:db');
+
+interface FindOneAndUpdateOptions extends FindOneAndUpdateOptions_orig {
+  includeResultMetadata: boolean; // support mongodb driver 6.0
+}
 
 const findOneAndUpdateCommonOptions = {
     includeResultMetadata: true, // mongodb driver 6.0 default is false, so we use true for backwards compatibility


### PR DESCRIPTION
MongoDB driver 6.0 no longer includes metadata on `findOneAndUpdate...` calls, so it returns the document at the root, rather than having to reach into `.value` to get the document.

The new option / default is `includeResultMetadata: false`

This commit provides backwards compatibility by passing the option `includeResultMetadata: true` to retain the old behavior.

FYI - I pass my own 6.0.0 driver instance in with `new Agenda({ mongo: ... });` and I've noticed zero issues with using newer drivers than `4.11.0` that this package is currently pinned to, and I've been using it for quite some time. I'd recommend testing yourself, then bumping `mongodb` in package.json to `^6.0` for some pretty decent driver performance improvements and bug fixes.