### PR TITLE
Update JobDbRepository.ts for handling mongo v6.

### DIFF
--- a/src/JobDbRepository.ts
+++ b/src/JobDbRepository.ts
@@ -155,6 +155,7 @@ export class JobDbRepository {
 		 */
 		const JOB_RETURN_QUERY: FindOneAndUpdateOptions = {
 			returnDocument: 'after',
+      includeResultMetadata: true,
 			sort: this.connectOptions.sort
 		};
 


### PR DESCRIPTION
Facing "result.value error" while getnextrun() when using mongo version 6. handling it by adding includeResultMetadata flag.